### PR TITLE
Change volume bindings and path for docker compose.

### DIFF
--- a/Fitness/Backend/docker-compose.development.yml
+++ b/Fitness/Backend/docker-compose.development.yml
@@ -48,7 +48,9 @@ services:
     ports:
       - "1433:1433"
     volumes:
-      - mssql_data:/var/opt/mssql
+      - mssql_data:/var/opt/mssql/data
+      - mssql_volume:/var/opt/sqlserver/
+  
   
   consul:
     container_name: consul

--- a/Fitness/Backend/docker-compose.development.yml
+++ b/Fitness/Backend/docker-compose.development.yml
@@ -48,8 +48,7 @@ services:
     ports:
       - "1433:1433"
     volumes:
-      - ~/docker/sql/mssql/data:/var/opt/mssql/data
-      - ~/docker/sql/sqlserver/:/var/opt/sqlserver/
+      - mssql_data:/var/opt/mssql
   
   consul:
     container_name: consul
@@ -57,7 +56,7 @@ services:
       - "8500:8500"
     command: "agent -dev -client=0.0.0.0"
     volumes:
-      - ~/docker/consul/data:/consul/data
+      - consul_data:/consul/data
       
   
   gatewayservice.api:

--- a/Fitness/Backend/docker-compose.yml
+++ b/Fitness/Backend/docker-compose.yml
@@ -90,6 +90,8 @@ volumes:
   clientmongo_data:
   paymentmongo_data:
   mssql_data:
+  mssql_volume:
   consul_data:
+
 
 


### PR DESCRIPTION
There was a problem on my machine after changing the 2017 to the 2022 version of the `mssql` container.

It turns out that Microsoft changed permissions related to volume mounting from the 2019 version onward (see [link](https://stackoverflow.com/questions/65601077/unable-to-run-sql-server-2019-docker-with-volumes-and-get-error-setup-failed-co) for details), resulting in an "access denied" error. One solution is to change the volume path in `docker-compose.development.yml`. This change ensures the container starts correctly and data is persisted.

Another change I made is regarding the host machine volumes location. We currently have an inconsistency: some volumes (`mssql` and `consul`) have manually set locations (e.g., `~/docker/...`), while others use the recommended Docker approach of letting Docker manage the volume location (defined in the `volumes` section of `docker-compose.yml` and referenced by name in `docker-compose.development.yml`). I suggest sticking with this recommended Docker approach for all volumes for consistency.  See the [Docker documentation](https://docs.docker.com/engine/storage/volumes/#start-a-container-with-a-volume) for more information.